### PR TITLE
Use the spec divergence half-angle

### DIFF
--- a/docs/src/assets/mi_assets/michelson_plots.jl
+++ b/docs/src/assets/mi_assets/michelson_plots.jl
@@ -1,22 +1,11 @@
-## intro fig
-GLMakie.activate!(; ssao=true)
-
-const intro_camera_view = [
-    -0.707107   0.707107  -5.55112e-17   0.0188074;
-    -0.498749  -0.498749   0.708871      0.222826;
-     0.501247   0.501247   0.705338     -0.759889;
-     0.0        0.0        0.0           1.0;
-]
-
-take_screenshot("mi_intro_fig.png", system, nothing; size=(600, 600), view=intro_camera_view)
-
 ## laser fig
 λ = 632.8e-9
 w0 = 0.65e-3 / 2
 
-θ_ideal = BeamletOptics.divergence_angle(λ, w0, 1) * 1e3
+θ_spec = 1.4e-3 / 2  # half-angle in mrad
+θ_ideal = BeamletOptics.divergence_angle(λ, w0, 1)
 
-M2 = 1.4 / θ_ideal
+M2 = θ_spec / θ_ideal
 
 beam = GaussianBeamlet([0.,0,0], [0.,1,0], λ, w0; M2)
 
@@ -175,3 +164,15 @@ save("mi_powerplot.png", power_fig, px_per_unit=4)
 # BeamletOptics.render_object_normals!(ax, pd.shape)
 
 # fig
+
+## intro fig
+GLMakie.activate!(; ssao=true)
+
+const intro_camera_view = [
+    -0.707107   0.707107  -5.55112e-17   0.0188074;
+    -0.498749  -0.498749   0.708871      0.222826;
+     0.501247   0.501247   0.705338     -0.759889;
+     0.0        0.0        0.0           1.0;
+]
+
+take_screenshot("mi_intro_fig.png", system, beam; size=(600, 600), view=intro_camera_view)

--- a/docs/src/assets/mi_assets/michelson_showcase.jl
+++ b/docs/src/assets/mi_assets/michelson_showcase.jl
@@ -56,7 +56,7 @@ arm_2 = ObjectGroup([m2, arm_holder_2])
 
 # PD
 pd_holder = MeshDummy(joinpath(asset_dir, "PD Assembly.stl"))
-pd = Photodetector(8e-3, 200)
+pd = Photodetector(5e-3, 200)
 translate3d!(pd, [0, -12cm, 0])
 
 pd_assembly = ObjectGroup([pd, pd_holder])

--- a/docs/src/tutorials/michelson.md
+++ b/docs/src/tutorials/michelson.md
@@ -65,7 +65,7 @@ The laser source for this interferometer will be a HeNe laser, e.g. the [HRS015B
 
 - wavelength `λ ≈ 632.8 nm`
 - waist diameter `d0 ≈ 0.65 mm`
-- beam divergence angle `θ ≈ 1.4 mrad`
+- beam divergence **full** angle `θ ≈ 1.4 mrad`
 
 To represent the HeNe beam in code, we use the [`GaussianBeamlet`](@ref) with parameters derived from the manufacturer data. The snippet below demonstrates how to initialize the beam. We can calculate the ideal divergence angle of the beam for the given wavelength and waist diameter and derive the [beam quality factor M²](https://www.rp-photonics.com/beam_quality.html) from there.
 
@@ -73,7 +73,7 @@ To represent the HeNe beam in code, we use the [`GaussianBeamlet`](@ref) with pa
 λ = 632.8e-9
 w0 = 0.65e-3 / 2
 
-θ_spec = 1.4e-3 / 2  # half-angle
+θ_spec = 1.4e-3 / 2  # half-angle in mrad
 θ_ideal = BeamletOptics.divergence_angle(λ, w0, 1)
 
 M2 = θ_spec / θ_ideal

--- a/docs/src/tutorials/michelson.md
+++ b/docs/src/tutorials/michelson.md
@@ -73,9 +73,10 @@ To represent the HeNe beam in code, we use the [`GaussianBeamlet`](@ref) with pa
 λ = 632.8e-9
 w0 = 0.65e-3 / 2
 
-θ_ideal = BeamletOptics.divergence_angle(λ, w0, 1) * 1e3
+θ_spec = 1.4e-3 / 2  # half-angle
+θ_ideal = BeamletOptics.divergence_angle(λ, w0, 1)
 
-M2 = 1.4 / θ_ideal
+M2 = θ_spec / θ_ideal
 
 beam = GaussianBeamlet(
     [0.0, 0.0, 0.0],   # Beam origin


### PR DESCRIPTION
BeamletOptics calculate the half-angle divergence (fine)
https://github.com/JuliaPhysics/BeamletOptics.jl/blob/99636a38497cf68f729761b2897f37ecc4ea345b/src/Utils/OpticUtils.jl#L63

but thorlabs [specifies the full-angle](https://www.thorlabs.com/newgrouppage9.cfm?objectgroup_id=5281&pn=HRS015B):

> The HRS015B beam divergence of 1.4 ± 0.2 mrad
is based on the 1/e² falloff, and is a full-angle measurement

So the actual M2 should be `1.13` (that looks plausible for an He-Ne) rather than `2.26`.

The last change displayed in the diff is actually only about `\ No newline at end of file`
(the line itself has not changed at all, only a newline character has been added automatically by github).
