### PR TITLE
Draft: Stub for coincident intersection

### DIFF
--- a/src/AbstractTypes/AbstractBeam.jl
+++ b/src/AbstractTypes/AbstractBeam.jl
@@ -75,6 +75,24 @@ function children!(beam::B, _children::AbstractVector{B}) where {B <: AbstractBe
     return error("Adding children to beam failed")
 end
 
+function children!(beam::B, _children::Tuple{Vararg{B}}) where {B <: AbstractBeam}
+    if isempty(children(beam))
+        # Link parent and add children to tree
+        for child in _children
+            parent!(child, beam)
+            push!(children(beam), child)
+        end
+        return nothing
+    end
+    if length(children(beam)) == length(_children)
+        for (i, child) in enumerate(children(beam))
+            _modify_beam_head!(child, _children[i])
+        end
+        return nothing
+    end
+    return error("Adding children to beam failed")
+end
+
 _drop_beams!(b::B) where {B <: AbstractBeam} = (b.children = Vector{B}())
 
 function _modify_beam_head!(::B, ::B) where {B <: AbstractBeam}

--- a/src/AbstractTypes/AbstractObject.jl
+++ b/src/AbstractTypes/AbstractObject.jl
@@ -94,4 +94,18 @@ Subtypes of `AbstractObjectGroup` must implement the following:
 """
 abstract type AbstractObjectGroup{T} <: AbstractObject{T} end
 
-AbstractTrees.children(group::AbstractObjectGroup) = group.objects
+AbstractTrees.children(group::AbstractObjectGroup) = objects(group)
+
+"""
+    is_refractive(object::AbstractObject)
+
+Default fallback implementation checking if an object has refractive properties. Returns `false`.
+"""
+is_refractive(::AbstractObject) = false
+
+"""
+    is_thin_interface(object::AbstractObject)
+
+Fallback implementation checking if an object is a zero-thickness boundary interface (like thin beamsplitter coatings or thin film coatings). Returns `false`.
+"""
+is_thin_interface(::AbstractObject) = false

--- a/src/AbstractTypes/AbstractRay.jl
+++ b/src/AbstractTypes/AbstractRay.jl
@@ -9,20 +9,29 @@ Stores data calculated by the [`intersect3d`](@ref) method. This information can
 - `shape`: a [`Nullable`](@ref) reference to the [`AbstractShape`](@ref) of the `object` that has been hit (optional but recommended)
 - `t`: length of the ray parametrization in [m]
 - `n`: normal vector at the point of intersection
+- `coincident_object`: a [`Nullable`](@ref) reference to the adjacent/exiting [`AbstractObject`](@ref) sharing the boundary (for doublets or coatings)
+- `coincident_object_2`: a [`Nullable`](@ref) reference to the adjacent/entering [`AbstractObject`](@ref) sharing the boundary (for coatings)
 """
 mutable struct Intersection{T}
     object::Nullable{AbstractObject}
     shape::Nullable{AbstractShape}
     t::T
     n::Point3{T}
+    coincident_object::Nullable{AbstractObject}
+    coincident_object_2::Nullable{AbstractObject}
 end
 
 function Intersection(t::T, n::AbstractArray{T}) where {T}
-    return Intersection(nothing, nothing, t, Point3{T}(n))
+    return Intersection(nothing, nothing, t, Point3{T}(n), nothing, nothing)
 end
 
 function Intersection(t::T, n::AbstractArray{T}, shape::Nullable{AbstractShape}) where {T}
-    return Intersection(nothing, shape, t, Point3{T}(n))
+    return Intersection(nothing, shape, t, Point3{T}(n), nothing, nothing)
+end
+
+function Intersection(object::Nullable{AbstractObject}, shape::Nullable{AbstractShape}, t::Real, n::Point3{S}) where {S}
+    T = promote_type(typeof(t), S)
+    return Intersection{T}(object, shape, T(t), Point3{T}(n), nothing, nothing)
 end
 
 shape(i::Intersection) = i.shape

--- a/src/BeamletOptics.jl
+++ b/src/BeamletOptics.jl
@@ -24,7 +24,8 @@ using .Config: get_invariant_threshold, set_invariant_threshold!,
              get_sdf_surface_threshold, get_sdf_raymarch_eps, get_sdf_inside_step,
              get_internal_reflection_threshold, get_line_plane_intersection_threshold,
              get_orthogonality_threshold, get_default_r_max, get_default_depth_max,
-             get_default_wavelength, get_default_waist, get_default_power
+             get_default_wavelength, get_default_waist, get_default_power,
+             get_coincident_boundary_tolerance, get_index_matching_tolerance
 include("Utils/Utils.jl")
 include("AbstractTypes/AbstractTypes.jl")
 include("Rays.jl")

--- a/src/Config.jl
+++ b/src/Config.jl
@@ -48,6 +48,8 @@ get_sdf_inside_step() = SDF_INSIDE_STEP
 const INTERNAL_REFLECTION_THRESHOLD = @load_preference("internal_reflection_threshold", 1e-6)
 const LINE_PLANE_INTERSECTION_THRESHOLD = @load_preference("line_plane_intersection_threshold", 1e-6)
 const ORTHOGONALITY_THRESHOLD = @load_preference("orthogonality_threshold", 1e-10)
+const COINCIDENT_BOUNDARY_TOLERANCE = @load_preference("coincident_boundary_tolerance", 1e-7)
+const INDEX_MATCHING_TOLERANCE = @load_preference("index_matching_tolerance", 1e-5)
 
 """
     get_internal_reflection_threshold()
@@ -69,6 +71,20 @@ get_line_plane_intersection_threshold() = LINE_PLANE_INTERSECTION_THRESHOLD
 Returns the global configuration threshold for orthogonality checks (e.g., beam support axes).
 """
 get_orthogonality_threshold() = ORTHOGONALITY_THRESHOLD
+
+"""
+    get_coincident_boundary_tolerance()
+
+Returns the global configuration threshold for identifying coincident boundaries (e.g., doublet lenses, prism-coating).
+"""
+get_coincident_boundary_tolerance() = COINCIDENT_BOUNDARY_TOLERANCE
+
+"""
+    get_index_matching_tolerance()
+
+Returns the global configuration threshold for comparing refractive indices at interfaces.
+"""
+get_index_matching_tolerance() = INDEX_MATCHING_TOLERANCE
 
 
 # --- Tracing Defaults ---

--- a/src/Exports.jl
+++ b/src/Exports.jl
@@ -56,7 +56,8 @@ export Retroreflector, get_invariant_threshold, set_invariant_threshold!,
     get_sdf_surface_threshold, get_sdf_raymarch_eps, get_sdf_inside_step,
     get_internal_reflection_threshold, get_line_plane_intersection_threshold,
     get_orthogonality_threshold, get_default_r_max, get_default_depth_max,
-    get_default_wavelength, get_default_waist, get_default_power
+    get_default_wavelength, get_default_waist, get_default_power,
+    get_coincident_boundary_tolerance, get_index_matching_tolerance
 
 # render
 export render!

--- a/src/OpticalComponents/Beamsplitters/CubeBeamsplitter.jl
+++ b/src/OpticalComponents/Beamsplitters/CubeBeamsplitter.jl
@@ -19,7 +19,7 @@ For more information refer to the [`AbstractPlateBeamsplitter`](@ref) docs.
     In order to model gap-free beam propagation, the `interact3d` model relies heavily on the [`Hint`](@ref)-API.
     If the `front` or `back` substrate is hit, the `Hint` will ensure that the beam intersects the `coating`.
 """
-struct CubeBeamsplitter{T} <: AbstractBeamsplitter{T}
+struct CubeBeamsplitter{T} <: AbstractObjectGroup{T}
     front::Prism{T, RightAnglePrismSDF{T}}
     back::Prism{T, RightAnglePrismSDF{T}}
     coating::ThinBeamsplitter{T, Mesh{T}}
@@ -28,6 +28,8 @@ end
 shape_trait_of(::CubeBeamsplitter) = MultiShape()
 
 shape(cbs::CubeBeamsplitter) = (cbs.front, cbs.back, cbs.coating)
+
+objects(cbs::CubeBeamsplitter) = (cbs.front, cbs.back, cbs.coating)
 
 refractive_index(cbs::CubeBeamsplitter, λ::Real) = refractive_index(cbs.front, λ)
 
@@ -58,93 +60,4 @@ function CubeBeamsplitter(
     zrotate3d!(bs, deg2rad(180-45))
     set_new_origin3d!(shape(bs))
     return CubeBeamsplitter(front, back, bs)
-end
-
-function interact3d(
-    system::AbstractSystem,
-    cbs::CubeBeamsplitter,
-    beam::Beam{T, R},
-    ray::R) where {T <: Real, R <: AbstractRay{T}}
-    # Front prism interaction
-    if shape(intersection(ray)) === shape(cbs.front)
-        interaction = interact3d(system, cbs.front, beam, ray)
-        # Hint towards coating
-        hint!(interaction, Hint(cbs, shape(cbs.coating)))
-        return interaction
-    end
-    # Splitter "coating" interaction
-    if shape(intersection(ray)) === shape(cbs.coating)
-        # Beamsplitter coating interaction
-        interact3d(system, cbs.coating, beam, ray)
-        # Update refractive index
-        _n = refractive_index(cbs, wavelength(ray))
-        refractive_index!(first(rays(beam.children[1])), _n)
-        refractive_index!(first(rays(beam.children[2])), _n)
-        return nothing
-    end
-    # Back prism interaction
-    if shape(intersection(ray)) === shape(cbs.back)
-        interaction = interact3d(system, cbs.back, beam, ray)
-        # Hint towards coating
-        hint!(interaction, Hint(cbs, shape(cbs.coating)))
-        return interaction
-    end
-end
-
-function interact3d(
-    system::AbstractSystem,
-    cbs::CubeBeamsplitter,
-    gauss::GaussianBeamlet,
-    id::Int)
-    _shape = shape(intersection(rays(gauss.chief)[id]))
-    # Front prism interaction
-    if _shape === shape(cbs.front)
-        interaction = interact3d(system, cbs.front, gauss, id)
-        hint!(interaction, Hint(cbs, shape(cbs.coating)))
-        return interaction
-    end
-    # Splitter "coating" interaction
-    if _shape === shape(cbs.coating)
-        interact3d(system, cbs.coating, gauss, id)
-        # Update refractive index
-        _n = refractive_index(cbs, wavelength(gauss))
-        refractive_index!(gauss.children[1], 1, _n)
-        refractive_index!(gauss.children[2], 1, _n)
-        return nothing
-    end
-    # Back prism interaction
-    if _shape === shape(cbs.back)
-        interaction = interact3d(system, cbs.back, gauss, id)
-        hint!(interaction, Hint(cbs, shape(cbs.coating)))
-        return interaction
-    end
-end
-
-function interact3d(
-    system::AbstractSystem,
-    cbs::CubeBeamsplitter,
-    agb::AstigmaticGaussianBeamlet,
-    id::Int)
-    _shape = shape(intersection(rays(agb.c)[id]))
-    # Front prism interaction
-    if _shape === shape(cbs.front)
-        interaction = interact3d(system, cbs.front, agb, id)
-        hint!(interaction, Hint(cbs, shape(cbs.coating)))
-        return interaction
-    end
-    # Splitter "coating" interaction
-    if _shape === shape(cbs.coating)
-        interact3d(system, cbs.coating, agb, id)
-        # Update refractive index
-        _n = refractive_index(cbs, wavelength(agb))
-        refractive_index!(agb.children[1], 1, _n)
-        refractive_index!(agb.children[2], 1, _n)
-        return nothing
-    end
-    # Back prism interaction
-    if _shape === shape(cbs.back)
-        interaction = interact3d(system, cbs.back, agb, id)
-        hint!(interaction, Hint(cbs, shape(cbs.coating)))
-        return interaction
-    end
 end

--- a/src/OpticalComponents/Beamsplitters/PlateBeamsplitter.jl
+++ b/src/OpticalComponents/Beamsplitters/PlateBeamsplitter.jl
@@ -30,7 +30,7 @@ If the concrete implementation does not define the above fields, the following g
     This type uses the [`Hint`](@ref)-API in order to ensure that the splitting interaction is correctly
     triggered at the coating.
 """
-abstract type AbstractPlateBeamsplitter{T} <: AbstractBeamsplitter{T} end
+abstract type AbstractPlateBeamsplitter{T} <: AbstractObjectGroup{T} end
 
 coating(pbs::AbstractPlateBeamsplitter) = pbs.coating
 substrate(pbs::AbstractPlateBeamsplitter) = pbs.substrate
@@ -42,6 +42,8 @@ orientation(pbs::AbstractPlateBeamsplitter) = orientation(substrate(pbs))
 shape_trait_of(::AbstractPlateBeamsplitter) = MultiShape()
 
 shape(pbs::AbstractPlateBeamsplitter) = (substrate(pbs), coating(pbs))
+
+objects(pbs::AbstractPlateBeamsplitter) = (substrate(pbs), coating(pbs))
 
 refractive_index(pbs::AbstractPlateBeamsplitter, λ::Real) = refractive_index(substrate(pbs), λ)
 
@@ -146,168 +148,7 @@ function RoundPlateBeamsplitter(
     # create substrate cylinder prism
     substrate_shape = PlanoSurfaceSDF(thickness, diameter)
     substrate = Prism(substrate_shape, n)
-    # round splitter coating (neg. y-axi normals)
+    # round splitter coating
     coating = RoundThinBeamsplitter(diameter; reflectance)
     return RoundPlateBeamsplitter(substrate, coating)
-end
-
-function intersect3d(pbs::AbstractPlateBeamsplitter, ray::AbstractRay)
-    # this is sooooooo stupid but necessary to ensure correct intersection... 
-    ic = intersect3d(coating(pbs), ray)
-    is = intersect3d(substrate(pbs), ray)
-    if isnothing(ic) & isnothing(is)
-        return nothing
-    end
-    if isnothing(is)
-        object!(ic, pbs)
-        return ic
-    end
-    if isnothing(ic)
-        object!(is, pbs)
-        return is
-    end
-    # if both shapes are hit, pick the coating
-    if length(ic) ≈ length(is)
-        object!(ic, pbs)
-        return ic
-    end
-    if length(ic) < length(is)
-        object!(ic, pbs)
-        return ic
-    else
-        object!(is, pbs)
-        return is
-    end
-end
-
-function interact3d(
-    system::AbstractSystem,
-    pbs::AbstractPlateBeamsplitter,
-    beam::Beam{T, R},
-    ray::R
-    ) where {T <: Real, R <: AbstractRay{T}}
-    # Substrate interaction
-    if shape(intersection(ray)) === shape(substrate(pbs))
-        interaction = interact3d(system, substrate(pbs), beam, ray)
-        # Hint towards coating
-        hint!(interaction, Hint(pbs, shape(coating(pbs))))
-        return interaction
-    end
-    # Splitter "coating" interaction
-    if shape(intersection(ray)) === shape(coating(pbs))
-        # Beamsplitter coating interaction
-        interact3d(system, coating(pbs), beam, ray)
-        # Update refractive index and calculate refraction
-        λ = wavelength(ray)
-        n_optics = refractive_index(pbs, λ)
-        n_system = refractive_index(system, λ)
-        if isentering(ray)
-            # transmitted ray is refracted into substrate
-            _nt = n_optics
-            _nr = n_system
-            n_d, _ = refraction3d(ray, n_optics)
-        else
-            # transmitted ray is refracted into environment
-            _nt = n_system
-            _nr = n_optics
-            n_d, _ = refraction3d(ray, n_system)
-        end
-        refractive_index!(first(rays(beam.children[1])), _nt)
-        refractive_index!(first(rays(beam.children[2])), _nr)
-        direction!(first(rays(beam.children[1])), n_d)
-        return nothing
-    end
-    # if nothing worked, return nothing
-    return nothing
-end
-
-function interact3d(
-    system::AbstractSystem,
-    pbs::AbstractPlateBeamsplitter,
-    gauss::GaussianBeamlet,
-    id::Int
-    )
-    _shape = shape(intersection(rays(gauss.chief)[id]))
-    # Substrate interaction
-    if _shape === shape(substrate(pbs))
-        interaction = interact3d(system, substrate(pbs), gauss, id)
-        hint!(interaction, Hint(pbs, shape(coating(pbs))))
-        return interaction
-    end
-    # Splitter interaction
-    if _shape === shape(coating(pbs))
-        interact3d(system, coating(pbs), gauss, id)
-        # Update refractive index and calculate refraction
-        λ = wavelength(rays(gauss.chief)[id])
-        n_optics = refractive_index(pbs, λ)
-        n_system = refractive_index(system, λ)
-        if isentering(gauss, id)
-            # transmitted ray is refracted into substrate
-            _nt = n_optics
-            _nr = n_system
-            n_c, _ = refraction3d(rays(gauss.chief)[id], n_optics) 
-            n_w, _ = refraction3d(rays(gauss.waist)[id], n_optics) 
-            n_d, _ = refraction3d(rays(gauss.divergence)[id], n_optics) 
-        else
-            # transmitted ray is refracted into environment
-            _nt = n_system
-            _nr = n_optics
-            n_c, _ = refraction3d(rays(gauss.chief)[id], n_system) 
-            n_w, _ = refraction3d(rays(gauss.waist)[id], n_system) 
-            n_d, _ = refraction3d(rays(gauss.divergence)[id], n_system) 
-        end
-        # Update children ref. index and dir. due to refraction
-        refractive_index!(gauss.children[1], 1, _nt)
-        refractive_index!(gauss.children[2], 1, _nr)
-        direction!(first(rays(gauss.children[1].chief)), n_c)
-        direction!(first(rays(gauss.children[1].waist)), n_w)
-        direction!(first(rays(gauss.children[1].divergence)), n_d)
-        return nothing
-    end
-    # if nothing worked, return nothing
-    return nothing
-end
-
-function interact3d(
-    system::AbstractSystem,
-    pbs::AbstractPlateBeamsplitter,
-    agb::AstigmaticGaussianBeamlet,
-    id::Int
-    )
-    _shape = shape(intersection(rays(agb.c)[id]))
-    # Substrate interaction
-    if _shape === shape(substrate(pbs))
-        interaction = interact3d(system, substrate(pbs), agb, id)
-        hint!(interaction, Hint(pbs, shape(coating(pbs))))
-        return interaction
-    end
-    # Splitter interaction
-    if _shape === shape(coating(pbs))
-        interact3d(system, coating(pbs), agb, id)
-        # Update refractive index and calculate refraction
-        λ = wavelength(rays(agb.c)[id])
-        n_optics = refractive_index(pbs, λ)
-        n_system = refractive_index(system, λ)
-        if isentering(agb, id)
-            # transmitted ray is refracted into substrate
-            _nt = n_optics
-            _nr = n_system
-        else
-            # transmitted ray is refracted into environment
-            _nt = n_system
-            _nr = n_optics
-        end
-        # Update children ref. index
-        refractive_index!(agb.children[1], 1, _nt)
-        refractive_index!(agb.children[2], 1, _nr)
-        # Calculate refracted directions for transmitted child's component beams
-        n_target = isentering(agb, id) ? n_optics : n_system
-        for (beam, pbeam) in zip(_component_beams(agb.children[1]), _component_beams(agb))
-            n_d, _ = refraction3d(rays(pbeam)[id], n_target)
-            direction!(first(rays(beam)), n_d)
-        end
-        return nothing
-    end
-    # if nothing worked, return nothing
-    return nothing
 end

--- a/src/OpticalComponents/Beamsplitters/ThinBeamsplitter.jl
+++ b/src/OpticalComponents/Beamsplitters/ThinBeamsplitter.jl
@@ -22,6 +22,8 @@ end
 reflectance(bs::ThinBeamsplitter) = bs.reflectance
 transmittance(bs::ThinBeamsplitter) = bs.transmittance
 
+is_thin_interface(::ThinBeamsplitter) = true
+
 """
     ThinBeamsplitter(width, height; reflectance=0.5)
 
@@ -72,58 +74,76 @@ end
 
 Base.isvalid(bs::AbstractBeamsplitter) = reflectance(bs)^2 + transmittance(bs)^2 ≈ 1
 
+@inline function _beamsplitter_media(system::AbstractSystem, ray::AbstractRay, int::Intersection)
+    λ = wavelength(ray)
+    n_incident = refractive_index(ray)
+    n_sys = refractive_index(system, λ)
+    
+    n_exit = isnothing(int.coincident_object) ? n_sys : refractive_index(int.coincident_object, λ)
+    n_enter = isnothing(int.coincident_object_2) ? n_sys : refractive_index(int.coincident_object_2, λ)
+    
+    tol = get_index_matching_tolerance()
+    if abs(n_incident - n_exit) < tol
+        n_reflected = n_exit
+        n_transmitted = n_enter
+    else
+        n_reflected = n_enter
+        n_transmitted = n_exit
+    end
+    return n_transmitted, n_reflected
+end
+
 @inline function _beamsplitter_transmitted_beam(
-        ::AbstractBeamsplitter, ::Beam{T, R}, ray::R) where {T <: Real, R <: Ray{T}}
+        ::AbstractBeamsplitter, ::Beam{T, R}, ray::R, n::Real, dir::AbstractVector) where {T <: Real, R <: Ray{T}}
     pos = position(ray) + length(ray) * direction(ray)
-    dir = direction(ray)
-    return Beam(Ray(pos, dir, wavelength(ray)))
+    return Beam(Ray{T}(Point3{T}(pos), Point3{T}(dir), nothing, wavelength(ray), n))
 end
 
 @inline function _beamsplitter_reflected_beam(
-        ::AbstractBeamsplitter, ::Beam{T, R}, ray::R) where {T <: Real, R <: Ray{T}}
-    normal = normal3d(intersection(ray))
+        ::AbstractBeamsplitter, ::Beam{T, R}, ray::R, n::Real, dir::AbstractVector) where {T <: Real, R <: Ray{T}}
     pos = position(ray) + length(ray) * direction(ray)
-    dir = reflection3d(direction(ray), normal)
-    return Beam(Ray(pos, dir, wavelength(ray)))
+    return Beam(Ray{T}(Point3{T}(pos), Point3{T}(dir), nothing, wavelength(ray), n))
 end
 
 @inline function _beamsplitter_transmitted_beam(bs::AbstractBeamsplitter, ::Beam{T, R},
-        ray::R) where {T <: Real, R <: PolarizedRay{T}}
+        ray::R, n::Real, dir::AbstractVector) where {T <: Real, R <: PolarizedRay{T}}
     J = SPBasis(transmittance(bs), 0, 0, transmittance(bs))
     pos = position(ray) + length(ray) * direction(ray)
-    dir = direction(ray)
     E0 = _calculate_global_E0(bs, ray, dir, J)
-    return Beam(PolarizedRay(pos, dir, wavelength(ray), E0))
+    return Beam(PolarizedRay{T}(pos, dir, nothing, wavelength(ray), n, E0))
 end
 
 @inline function _beamsplitter_reflected_beam(bs::AbstractBeamsplitter, ::Beam{T, R},
-        ray::R) where {T <: Real, R <: PolarizedRay{T}}
+        ray::R, n::Real, dir::AbstractVector) where {T <: Real, R <: PolarizedRay{T}}
     J = SPBasis(-reflectance(bs), 0, 0, reflectance(bs))
-    normal = normal3d(intersection(ray))
     pos = position(ray) + length(ray) * direction(ray)
-    in_dir = direction(ray)
-    out_dir = reflection3d(in_dir, normal)
-    E0 = _calculate_global_E0(bs, ray, out_dir, J)
-    return Beam(PolarizedRay(pos, out_dir, wavelength(ray), E0))
+    E0 = _calculate_global_E0(bs, ray, dir, J)
+    return Beam(PolarizedRay{T}(pos, dir, nothing, wavelength(ray), n, E0))
 end
 
-function interact3d(::AbstractSystem, bs::ThinBeamsplitter, beam::Beam{T, R},
+function interact3d(system::AbstractSystem, bs::ThinBeamsplitter, beam::Beam{T, R},
         ray::R) where {T <: Real, R <: AbstractRay{T}}
-    # Push transmitted and reflected beams to system
+    int = intersection(ray)
+    n_transmitted, n_reflected = _beamsplitter_media(system, ray, int)
+    
+    normal = normal3d(int)
+    if dot(direction(ray), normal) > 0
+        normal = -normal
+    end
+    dir_t, _ = refraction3d(direction(ray), normal, refractive_index(ray), n_transmitted)
+    dir_r = reflection3d(direction(ray), normal)
+    
     children!(beam,
-        [_beamsplitter_transmitted_beam(bs, beam, ray),
-            _beamsplitter_reflected_beam(bs, beam, ray)])
-    # Stop for beam spawning
+        (_beamsplitter_transmitted_beam(bs, beam, ray, n_transmitted, dir_t),
+         _beamsplitter_reflected_beam(bs, beam, ray, n_reflected, dir_r)))
     return nothing
 end
 
 @inline function _beamsplitter_transmitted_beam(
-        bs::AbstractBeamsplitter, gauss::GaussianBeamlet, ray_id::Int)
-    # Transmitted Gaussian (no phase flip)
-    chief = _beamsplitter_transmitted_beam(bs, gauss.chief, rays(gauss.chief)[ray_id])
-    waist = _beamsplitter_transmitted_beam(bs, gauss.waist, rays(gauss.waist)[ray_id])
-    divergence = _beamsplitter_transmitted_beam(
-        bs, gauss.divergence, rays(gauss.divergence)[ray_id])
+        bs::AbstractBeamsplitter, gauss::GaussianBeamlet, ray_id::Int, n::Real, c_dir::AbstractVector, w_dir::AbstractVector, d_dir::AbstractVector)
+    chief = _beamsplitter_transmitted_beam(bs, gauss.chief, rays(gauss.chief)[ray_id], n, c_dir)
+    waist = _beamsplitter_transmitted_beam(bs, gauss.waist, rays(gauss.waist)[ray_id], n, w_dir)
+    divergence = _beamsplitter_transmitted_beam(bs, gauss.divergence, rays(gauss.divergence)[ray_id], n, d_dir)
     λ = wavelength(gauss)
     w0 = gauss_parameters(gauss, length(gauss))[4]
     E0 = transmittance(bs) * electric_field(gauss) * (beam_waist(gauss) / w0)
@@ -131,99 +151,121 @@ end
 end
 
 @inline function _beamsplitter_reflected_beam(
-        bs::AbstractBeamsplitter, gauss::GaussianBeamlet, ray_id::Int)
-    # Reflected Gaussian (no phase flip)
-    chief = _beamsplitter_reflected_beam(bs, gauss.chief, rays(gauss.chief)[ray_id])
-    waist = _beamsplitter_reflected_beam(bs, gauss.waist, rays(gauss.waist)[ray_id])
-    divergence = _beamsplitter_reflected_beam(
-        bs, gauss.divergence, rays(gauss.divergence)[ray_id])
+        bs::AbstractBeamsplitter, gauss::GaussianBeamlet, ray_id::Int, n::Real, c_dir::AbstractVector, w_dir::AbstractVector, d_dir::AbstractVector)
+    chief = _beamsplitter_reflected_beam(bs, gauss.chief, rays(gauss.chief)[ray_id], n, c_dir)
+    waist = _beamsplitter_reflected_beam(bs, gauss.waist, rays(gauss.waist)[ray_id], n, w_dir)
+    divergence = _beamsplitter_reflected_beam(bs, gauss.divergence, rays(gauss.divergence)[ray_id], n, d_dir)
     λ = wavelength(gauss)
     w0 = gauss_parameters(gauss, length(gauss))[4]
     E0 = reflectance(bs) * electric_field(gauss) * (beam_waist(gauss) / w0)
     return GaussianBeamlet(chief, waist, divergence, λ, w0, E0)
 end
 
-"""
-    interact3d(::AbstractSystem, bs::ThinBeamsplitter, gauss::GaussianBeamlet, ray_id::Int)
-
-Models the interaction between a [`ThinBeamsplitter`](@ref) and a [`GaussianBeamlet`](@ref).
-
-# Reflection phase jump
-
-The reflection phase jump is modeled here as θᵣ = π for simplicity. This is since in practice it will have only a relative effect on the signal at the detector for interferometric setups.
-The phase jump is applied to the reflected portion of any incoming beam that faces the [`ThinBeamsplitter`](@ref) normal vector, which assumes that the splitter has an unambigous normal, i.e. a 2D mesh.
-This is intended to model the effect of the Fresnel equations without full polarization calculus.
-"""
 function interact3d(
-        ::AbstractSystem, bs::ThinBeamsplitter, gauss::GaussianBeamlet, ray_id::Int)
-    # Phase flip
-    ray = gauss.chief.rays[ray_id]
-    df = dot(direction(ray), normal3d(intersection(ray)))
-    if df < 0
-        ϕ = π
-    else
-        ϕ = 0
+        system::AbstractSystem, bs::ThinBeamsplitter, gauss::GaussianBeamlet, ray_id::Int)
+    c_ray = gauss.chief.rays[ray_id]
+    w_ray = gauss.waist.rays[ray_id]
+    d_ray = gauss.divergence.rays[ray_id]
+    
+    int = intersection(c_ray)
+    n_transmitted, n_reflected = _beamsplitter_media(system, c_ray, int)
+    
+    normal = normal3d(int)
+    if dot(direction(c_ray), normal) > 0
+        normal = -normal
     end
-
-    t = _beamsplitter_transmitted_beam(bs, gauss, ray_id)
-    r = _beamsplitter_reflected_beam(bs, gauss, ray_id)
-
-    # Add conditional phase flip to reflected beam
+    
+    c_dir_t, _ = refraction3d(direction(c_ray), normal, refractive_index(c_ray), n_transmitted)
+    w_dir_t, _ = refraction3d(direction(w_ray), normal, refractive_index(w_ray), n_transmitted)
+    d_dir_t, _ = refraction3d(direction(d_ray), normal, refractive_index(d_ray), n_transmitted)
+    
+    c_dir_r = reflection3d(direction(c_ray), normal)
+    w_dir_r = reflection3d(direction(w_ray), normal)
+    d_dir_r = reflection3d(direction(d_ray), normal)
+    
+    t = _beamsplitter_transmitted_beam(bs, gauss, ray_id, n_transmitted, c_dir_t, w_dir_t, d_dir_t)
+    r = _beamsplitter_reflected_beam(bs, gauss, ray_id, n_reflected, c_dir_r, w_dir_r, d_dir_r)
+    
+    df = dot(direction(c_ray), normal3d(int))
+    ϕ = df < 0 ? π : 0
     electric_field!(r, electric_field(r) * exp(im * ϕ))
 
-    children!(gauss, [t, r])
+    children!(gauss, (t, r))
     return nothing
 end
 
 @inline function _beamsplitter_transmitted_beam(
-        bs::AbstractBeamsplitter, agb::AstigmaticGaussianBeamlet, ray_id::Int)
-    c = _beamsplitter_transmitted_beam(bs, agb.c, rays(agb.c)[ray_id])
-    wxp = _beamsplitter_transmitted_beam(bs, agb.wxp, rays(agb.wxp)[ray_id])
-    wxm = _beamsplitter_transmitted_beam(bs, agb.wxm, rays(agb.wxm)[ray_id])
-    wyp = _beamsplitter_transmitted_beam(bs, agb.wyp, rays(agb.wyp)[ray_id])
-    wym = _beamsplitter_transmitted_beam(bs, agb.wym, rays(agb.wym)[ray_id])
-    dxp = _beamsplitter_transmitted_beam(bs, agb.dxp, rays(agb.dxp)[ray_id])
-    dxm = _beamsplitter_transmitted_beam(bs, agb.dxm, rays(agb.dxm)[ray_id])
-    dyp = _beamsplitter_transmitted_beam(bs, agb.dyp, rays(agb.dyp)[ray_id])
-    dym = _beamsplitter_transmitted_beam(bs, agb.dym, rays(agb.dym)[ray_id])
+        bs::AbstractBeamsplitter, agb::AstigmaticGaussianBeamlet, ray_id::Int, n::Real, dirs::Tuple)
+    c = _beamsplitter_transmitted_beam(bs, agb.c, rays(agb.c)[ray_id], n, dirs[1])
+    wxp = _beamsplitter_transmitted_beam(bs, agb.wxp, rays(agb.wxp)[ray_id], n, dirs[2])
+    wxm = _beamsplitter_transmitted_beam(bs, agb.wxm, rays(agb.wxm)[ray_id], n, dirs[3])
+    wyp = _beamsplitter_transmitted_beam(bs, agb.wyp, rays(agb.wyp)[ray_id], n, dirs[4])
+    wym = _beamsplitter_transmitted_beam(bs, agb.wym, rays(agb.wym)[ray_id], n, dirs[5])
+    dxp = _beamsplitter_transmitted_beam(bs, agb.dxp, rays(agb.dxp)[ray_id], n, dirs[6])
+    dxm = _beamsplitter_transmitted_beam(bs, agb.dxm, rays(agb.dxm)[ray_id], n, dirs[7])
+    dyp = _beamsplitter_transmitted_beam(bs, agb.dyp, rays(agb.dyp)[ray_id], n, dirs[8])
+    dym = _beamsplitter_transmitted_beam(bs, agb.dym, rays(agb.dym)[ray_id], n, dirs[9])
     return AstigmaticGaussianBeamlet(c, wxp, wxm, wyp, wym, dxp, dxm, dyp, dym)
 end
 
 @inline function _beamsplitter_reflected_beam(
-        bs::AbstractBeamsplitter, agb::AstigmaticGaussianBeamlet, ray_id::Int)
-    c = _beamsplitter_reflected_beam(bs, agb.c, rays(agb.c)[ray_id])
-    wxp = _beamsplitter_reflected_beam(bs, agb.wxp, rays(agb.wxp)[ray_id])
-    wxm = _beamsplitter_reflected_beam(bs, agb.wxm, rays(agb.wxm)[ray_id])
-    wyp = _beamsplitter_reflected_beam(bs, agb.wyp, rays(agb.wyp)[ray_id])
-    wym = _beamsplitter_reflected_beam(bs, agb.wym, rays(agb.wym)[ray_id])
-    dxp = _beamsplitter_reflected_beam(bs, agb.dxp, rays(agb.dxp)[ray_id])
-    dxm = _beamsplitter_reflected_beam(bs, agb.dxm, rays(agb.dxm)[ray_id])
-    dyp = _beamsplitter_reflected_beam(bs, agb.dyp, rays(agb.dyp)[ray_id])
-    dym = _beamsplitter_reflected_beam(bs, agb.dym, rays(agb.dym)[ray_id])
+        bs::AbstractBeamsplitter, agb::AstigmaticGaussianBeamlet, ray_id::Int, n::Real, dirs::Tuple)
+    c = _beamsplitter_reflected_beam(bs, agb.c, rays(agb.c)[ray_id], n, dirs[1])
+    wxp = _beamsplitter_reflected_beam(bs, agb.wxp, rays(agb.wxp)[ray_id], n, dirs[2])
+    wxm = _beamsplitter_reflected_beam(bs, agb.wxm, rays(agb.wxm)[ray_id], n, dirs[3])
+    wyp = _beamsplitter_reflected_beam(bs, agb.wyp, rays(agb.wyp)[ray_id], n, dirs[4])
+    wym = _beamsplitter_reflected_beam(bs, agb.wym, rays(agb.wym)[ray_id], n, dirs[5])
+    dxp = _beamsplitter_reflected_beam(bs, agb.dxp, rays(agb.dxp)[ray_id], n, dirs[6])
+    dxm = _beamsplitter_reflected_beam(bs, agb.dxm, rays(agb.dxm)[ray_id], n, dirs[7])
+    dyp = _beamsplitter_reflected_beam(bs, agb.dyp, rays(agb.dyp)[ray_id], n, dirs[8])
+    dym = _beamsplitter_reflected_beam(bs, agb.dym, rays(agb.dym)[ray_id], n, dirs[9])
     return AstigmaticGaussianBeamlet(c, wxp, wxm, wyp, wym, dxp, dxm, dyp, dym)
 end
 
-"""
-    interact3d(::AbstractSystem, bs::ThinBeamsplitter, agb::AstigmaticGaussianBeamlet, ray_id::Int)
-
-Models the interaction between a [`ThinBeamsplitter`](@ref) and an [`AstigmaticGaussianBeamlet`](@ref).
-The reflection phase jump θᵣ = π is applied to the reflected child beam.
-"""
 function interact3d(
-        ::AbstractSystem, bs::ThinBeamsplitter, agb::AstigmaticGaussianBeamlet, ray_id::Int)
-    # Phase flip
-    ray = rays(agb.c)[ray_id]
-    df = dot(direction(ray), normal3d(intersection(ray)))
+        system::AbstractSystem, bs::ThinBeamsplitter, agb::AstigmaticGaussianBeamlet, ray_id::Int)
+    c_ray = rays(agb.c)[ray_id]
+    int = intersection(c_ray)
+    n_transmitted, n_reflected = _beamsplitter_media(system, c_ray, int)
+    
+    normal = normal3d(int)
+    if dot(direction(c_ray), normal) > 0
+        normal = -normal
+    end
+    
+    dirs_t = (
+        refraction3d(rays(agb.c)[ray_id], n_transmitted)[1],
+        refraction3d(rays(agb.wxp)[ray_id], n_transmitted)[1],
+        refraction3d(rays(agb.wxm)[ray_id], n_transmitted)[1],
+        refraction3d(rays(agb.wyp)[ray_id], n_transmitted)[1],
+        refraction3d(rays(agb.wym)[ray_id], n_transmitted)[1],
+        refraction3d(rays(agb.dxp)[ray_id], n_transmitted)[1],
+        refraction3d(rays(agb.dxm)[ray_id], n_transmitted)[1],
+        refraction3d(rays(agb.dyp)[ray_id], n_transmitted)[1],
+        refraction3d(rays(agb.dym)[ray_id], n_transmitted)[1]
+    )
+    dirs_r = (
+        reflection3d(direction(rays(agb.c)[ray_id]), normal3d(intersection(rays(agb.c)[ray_id]))),
+        reflection3d(direction(rays(agb.wxp)[ray_id]), normal3d(intersection(rays(agb.wxp)[ray_id]))),
+        reflection3d(direction(rays(agb.wxm)[ray_id]), normal3d(intersection(rays(agb.wxm)[ray_id]))),
+        reflection3d(direction(rays(agb.wyp)[ray_id]), normal3d(intersection(rays(agb.wyp)[ray_id]))),
+        reflection3d(direction(rays(agb.wym)[ray_id]), normal3d(intersection(rays(agb.wym)[ray_id]))),
+        reflection3d(direction(rays(agb.dxp)[ray_id]), normal3d(intersection(rays(agb.dxp)[ray_id]))),
+        reflection3d(direction(rays(agb.dxm)[ray_id]), normal3d(intersection(rays(agb.dxm)[ray_id]))),
+        reflection3d(direction(rays(agb.dyp)[ray_id]), normal3d(intersection(rays(agb.dyp)[ray_id]))),
+        reflection3d(direction(rays(agb.dym)[ray_id]), normal3d(intersection(rays(agb.dym)[ray_id])))
+    )
+
+    t = _beamsplitter_transmitted_beam(bs, agb, ray_id, n_transmitted, dirs_t)
+    r = _beamsplitter_reflected_beam(bs, agb, ray_id, n_reflected, dirs_r)
+
+    df = dot(direction(c_ray), normal3d(int))
     ϕ = df < 0 ? π : 0
-
-    t = _beamsplitter_transmitted_beam(bs, agb, ray_id)
-    r = _beamsplitter_reflected_beam(bs, agb, ray_id)
-
     # Add conditional phase flip to reflected beam chief polarization
     chief_ray = first(rays(r.c))
     E_new = polarization(chief_ray) * exp(im * ϕ)
     polarization!(chief_ray, E_new)
 
-    children!(agb, [t, r])
+    children!(agb, (t, r))
     return nothing
 end

--- a/src/OpticalComponents/DoubletLenses.jl
+++ b/src/OpticalComponents/DoubletLenses.jl
@@ -4,7 +4,7 @@ abstract type AbstractDoubletRefractiveOptic{
     B <: AbstractShape{T},
     N1 <: RefractiveIndex,
     N2 <: RefractiveIndex
-} <: AbstractRefractiveOptic{T, N1} end
+} <: AbstractObjectGroup{T} end
 
 """
     DoubletLens
@@ -28,9 +28,25 @@ struct DoubletLens{T, F<:AbstractShape{T}, B<:AbstractShape{T}, N1<:RefractiveIn
     back::Lens{T, B, N2}
 end
 
+function DoubletLens(front::Lens{T, F, N1}, back::Lens{T, B, N2}) where {T, F, B, N1, N2}
+    # Check if they are flush and aligned along the optical axis
+    rel_pos = position(back) - position(front)
+    opt_axis = orientation(front)[:, 2]
+    expected_offset = thickness(front)
+    if !isapprox(rel_pos, expected_offset * opt_axis, atol=1e-5)
+        @warn "Doublet components are not aligned flush along the optical axis (expected offset $(expected_offset)m along orientation axis, got $(rel_pos)m). This may cause tracing errors at coincident boundaries."
+    end
+    if !isapprox(orientation(front), orientation(back), atol=1e-5)
+        @warn "Doublet components do not have matching orientation. This may cause tracing errors at coincident boundaries."
+    end
+    return DoubletLens{T, F, B, N1, N2}(front, back)
+end
+
 shape_trait_of(::DoubletLens) = MultiShape()
 
 shape(dl::DoubletLens) = (dl.front, dl.back)
+
+objects(dl::DoubletLens) = (dl.front, dl.back)
 
 Base.position(dl::DoubletLens) = position(dl.front)
 orientation(dl::DoubletLens) = orientation(dl.front)
@@ -52,7 +68,7 @@ For radii sign definition, refer to the [`SphericalLens`](@ref) constructor.
 - `l2`: second lens thickness
 - `d`: lens diameter
 - `n1`: first lens [`RefractiveIndex`](@ref)
-- `n1`: second lens [`RefractiveIndex`](@ref)
+- `n2`: second lens [`RefractiveIndex`](@ref)
 """
 function SphericalDoubletLens(r1, r2, r3, l1, l2, d, n1, n2)
     # Generate "cemented" front and back spherical lenses
@@ -61,16 +77,4 @@ function SphericalDoubletLens(r1, r2, r3, l1, l2, d, n1, n2)
     # Move doublet parts into position
     translate3d!(back, [0, thickness(shape(front)), 0])
     return DoubletLens(front, back)
-end
-
-function interact3d(system::AbstractSystem, dl::DoubletLens, beam::Beam{T, R}, ray::R) where {T <: Real, R <: Ray{T}}
-    # Interaction logic: if front is hit, hint to back and vice versa
-    if shape(intersection(ray)) === shape(dl.front)
-        i = interact3d(system, dl.front, beam, ray)
-        hint = Hint(dl, dl.back.shape)
-    elseif shape(intersection(ray)) === shape(dl.back)
-        i = interact3d(system, dl.back, beam, ray)
-        hint = Hint(dl, dl.front.shape)
-    end
-    return BeamInteraction(hint, i.ray)
 end

--- a/src/OpticalComponents/Lenses.jl
+++ b/src/OpticalComponents/Lenses.jl
@@ -88,7 +88,7 @@ end
 """
     interact3d(AbstractSystem, AbstractRefractiveOptic, Beam, PolarizedRay)
 
-Implements the refraction of a [`PolarizedRay`](@ref) at uncoated optical surface. The "outside" ref. index is obtained from the `system` unless specified otherwise.
+Implements the refraction of a [`PolarizedRay`](@ref) at uncoated optical surfaces. The "outside" ref. index is obtained from the `system` unless specified otherwise.
 Reflection and transmission values are calculated via the [`fresnel_coefficients`](@ref). Stray light is not tracked.
 In the case of total internal reflection, only the reflected light is traced.
 """
@@ -257,7 +257,8 @@ function Lens(
                     end
 
                     ring = RingSDF(d_front / 2, (d_back - d_front) / 2, leveling_thickness)
-                    translate3d!(ring, [0, edge_sag(front_surface, front) + leveling_thickness / 2, 0])
+                    translate3d!(ring,
+                        [0, edge_sag(front_surface, front) + leveling_thickness / 2, 0])
                     shape += ring
                 else  # d_front > d_back
                     # Step exists on the back side: level back to match front.
@@ -271,12 +272,14 @@ function Lens(
                         end
                     end
                     leveling_center = position(mid)[2] +
-                                      (l0/2 + (back !== nothing ? edge_sag(back_surface, back) : 0))
+                                      (l0 / 2 +
+                                       (back !== nothing ? edge_sag(back_surface, back) :
+                                        0))
                     if back !== nothing
                         leveling_center += s_back / 2
                     end
                     ring = RingSDF(d_back / 2, (d_front - d_back) / 2, leveling_thickness)
-                    translate3d!(ring, [0, thickness(front) + leveling_thickness/2, 0])
+                    translate3d!(ring, [0, thickness(front) + leveling_thickness / 2, 0])
                     shape += ring
                 end
             end

--- a/src/OpticalComponents/Lenses.jl
+++ b/src/OpticalComponents/Lenses.jl
@@ -37,6 +37,8 @@ abstract type AbstractRefractiveOptic{T, F} <: AbstractObject{T} end
 refractive_index(object::AbstractRefractiveOptic) = object.n
 refractive_index(object::AbstractRefractiveOptic{<:Any, <:RefractiveIndex}, λ::Real)::Float64 = object.n(λ)
 
+is_refractive(::AbstractRefractiveOptic) = true
+
 """
     interact3d(AbstractSystem, AbstractRefractiveOptic, Beam, Ray)
 
@@ -48,7 +50,8 @@ function interact3d(system::AbstractSystem,
         ::Beam{T, R},
         ray::R) where {T <: Real, R <: Ray{T}}
     # Check dir. of ray and surface normal
-    normal = normal3d(intersection(ray))
+    int = intersection(ray)
+    normal = normal3d(int)
     lambda = wavelength(ray)
     if isentering(ray)
         # Entering optic
@@ -59,8 +62,14 @@ function interact3d(system::AbstractSystem,
     else
         # Exiting optic
         n1 = refractive_index(optic, lambda)
-        n2 = refractive_index(system, lambda)
-        hint = nothing
+        coin_obj = int.coincident_object
+        if !isnothing(coin_obj) && is_refractive(coin_obj)
+            n2 = refractive_index(coin_obj, lambda)
+            hint = Hint(coin_obj)
+        else
+            n2 = refractive_index(system, lambda)
+            hint = nothing
+        end
         # Flip normal for refraction3d
         normal = -normal
     end
@@ -79,14 +88,15 @@ end
 """
     interact3d(AbstractSystem, AbstractRefractiveOptic, Beam, PolarizedRay)
 
-Implements the refraction of a [`PolarizedRay`](@ref) at an uncoated optical surface. The "outside" ref. index is obtained from the `system` unless specified otherwise.
+Implements the refraction of a [`PolarizedRay`](@ref) at uncoated optical surface. The "outside" ref. index is obtained from the `system` unless specified otherwise.
 Reflection and transmission values are calculated via the [`fresnel_coefficients`](@ref). Stray light is not tracked.
 In the case of total internal reflection, only the reflected light is traced.
 """
 function interact3d(system::AbstractSystem, optic::AbstractRefractiveOptic,
         ::Beam{T, R}, ray::R) where {T <: Real, R <: PolarizedRay{T}}
     lambda = wavelength(ray)
-    normal = normal3d(intersection(ray))
+    int = intersection(ray)
+    normal = normal3d(int)
     raypos = position(ray) + length(ray) * direction(ray)
     if isentering(ray)
         # Entering optic
@@ -97,8 +107,14 @@ function interact3d(system::AbstractSystem, optic::AbstractRefractiveOptic,
     else
         # Exiting optic
         n1 = refractive_index(optic, lambda)
-        n2 = refractive_index(system, lambda)
-        hint = nothing
+        coin_obj = int.coincident_object
+        if !isnothing(coin_obj) && is_refractive(coin_obj)
+            n2 = refractive_index(coin_obj, lambda)
+            hint = Hint(coin_obj)
+        else
+            n2 = refractive_index(system, lambda)
+            hint = nothing
+        end
         # Flip normal for refraction3d
         normal = -normal
     end

--- a/src/System.jl
+++ b/src/System.jl
@@ -57,35 +57,276 @@ function retrace_system!(::AbstractSystem, beam::B) where {B <: AbstractBeam}
 end
 
 @inline function trace_all(system::AbstractSystem, ray::AbstractRay{R}) where {R}
-    result::Union{Nothing, Intersection{R}} = nothing
+    tol = get_coincident_boundary_tolerance()
+    best_t = R(Inf)
+    best_int = nothing
+    coin_1 = nothing
+    coin_2 = nothing
+
+    # Find the closest intersection and collect any coincident ones at the same distance
     for obj in objects(system)
-        # Find shortest intersection
-        temp::Union{Nothing, Intersection{R}} = intersect3d(obj, ray)
+        temp = intersect3d(obj, ray)
         if temp === nothing
             continue
         end
+        t = length(temp)
 
-        # Catch first valid intersection and replace current with closer intersection
-        if result === nothing || length(temp) < length(result)
-            result = temp
+        # Ignore self-intersection (t ≈ 0)
+        if t <= tol
+            continue
+        end
+
+        if t < best_t - tol
+            best_t = t
+            best_int = temp
+            coin_1 = nothing
+            coin_2 = nothing
+        elseif abs(t - best_t) <= tol
+            if coin_1 === nothing
+                coin_1 = temp
+            elseif coin_2 === nothing
+                coin_2 = temp
+            end
         end
     end
-    return result
+
+    if best_int === nothing
+        return nothing
+    end
+
+    # Tie-break coincident boundaries
+    if coin_1 === nothing
+        return best_int
+    end
+
+    # Determine if any of the valid intersections is a thin interface
+    primary = nothing
+    if is_thin_interface(object(best_int))
+        primary = best_int
+    elseif is_thin_interface(object(coin_1))
+        primary = coin_1
+    elseif coin_2 !== nothing && is_thin_interface(object(coin_2))
+        primary = coin_2
+    end
+
+    if primary !== nothing
+        # Case 1: Thin interface (coating) between two media. Return the coating
+        # as primary, and link the exiting and entering objects to resolve indices.
+        exiting_obj = nothing
+        entering_obj = nothing
+
+        # Examine best_int
+        if best_int !== primary
+            obj_best = object(best_int)
+            if obj_best !== nothing
+                if dot(direction(ray), normal3d(best_int)) > 0
+                    exiting_obj = obj_best
+                else
+                    entering_obj = obj_best
+                end
+            end
+        end
+
+        # Examine coin_1
+        if coin_1 !== primary
+            obj_c1 = object(coin_1)
+            if obj_c1 !== nothing
+                if dot(direction(ray), normal3d(coin_1)) > 0
+                    exiting_obj = obj_c1
+                else
+                    entering_obj = obj_c1
+                end
+            end
+        end
+
+        # Examine coin_2
+        if coin_2 !== nothing && coin_2 !== primary
+            obj_c2 = object(coin_2)
+            if obj_c2 !== nothing
+                if dot(direction(ray), normal3d(coin_2)) > 0
+                    exiting_obj = obj_c2
+                else
+                    entering_obj = obj_c2
+                end
+            end
+        end
+
+        primary.coincident_object = exiting_obj
+        primary.coincident_object_2 = entering_obj
+        return primary
+    else
+        # Case 2: Touching refractive boundaries (doublet contact). Return the
+        # exiting shape as primary, and link the entering shape as coincident_object.
+        exiting_int = nothing
+        entering_int = nothing
+
+        # Examine best_int
+        if dot(direction(ray), normal3d(best_int)) > 0
+            exiting_int = best_int
+        else
+            entering_int = best_int
+        end
+
+        # Examine coin_1
+        if dot(direction(ray), normal3d(coin_1)) > 0
+            exiting_int = coin_1
+        else
+            entering_int = coin_1
+        end
+
+        # Examine coin_2
+        if coin_2 !== nothing
+            if dot(direction(ray), normal3d(coin_2)) > 0
+                exiting_int = coin_2
+            else
+                entering_int = coin_2
+            end
+        end
+
+        if exiting_int !== nothing && entering_int !== nothing
+            exiting_int.coincident_object = object(entering_int)
+            return exiting_int
+        elseif exiting_int !== nothing
+            return exiting_int
+        else
+            return best_int
+        end
+    end
 end
 
 @inline function trace_one(
         system::AbstractSystem, ray::AbstractRay{R}, hint::Hint) where {R}
-    # Trace against hinted shape of object
-    intersection::Nullable{Intersection{R}} = intersect3d(
+    tol = get_coincident_boundary_tolerance()
+    # Trace against hinted shape of object first
+    primary::Nullable{Intersection{R}} = intersect3d(
         shape(hint)::AbstractShape{R}, ray)
-    if isnothing(intersection)
+    if primary === nothing
         # If hinted object is not intersected, trace the entire system
-        intersection = trace_all(system, ray)
-    else
-        # If hinted object is intersected, update intersection
-        object!(intersection, object(hint))
+        return trace_all(system, ray)
     end
-    return intersection
+
+    object!(primary, object(hint))
+    t_best = length(primary)
+    if t_best <= tol
+        # Ignore self-intersection/coincident boundary re-entry
+        return trace_all(system, ray)
+    end
+
+    # Gather other intersections at the same distance to resolve cement/contact transitions
+    coin_1 = nothing
+    coin_2 = nothing
+    for obj in objects(system)
+        if obj === object(hint)
+            continue
+        end
+        temp = intersect3d(obj, ray)
+        if temp !== nothing && abs(length(temp) - t_best) <= tol
+            if coin_1 === nothing
+                coin_1 = temp
+            elseif coin_2 === nothing
+                coin_2 = temp
+            end
+        end
+    end
+
+    # If no coincident intersections, just return primary
+    if coin_1 === nothing
+        return primary
+    end
+
+    # Determine if any of the valid intersections is a thin interface
+    thin_primary = nothing
+    if is_thin_interface(object(primary))
+        thin_primary = primary
+    elseif is_thin_interface(object(coin_1))
+        thin_primary = coin_1
+    elseif coin_2 !== nothing && is_thin_interface(object(coin_2))
+        thin_primary = coin_2
+    end
+
+    if thin_primary !== nothing
+        # Case 1: Thin interface (coating) between two media. Return the coating
+        # as primary, and link the exiting and entering objects to resolve indices.
+        exiting_obj = nothing
+        entering_obj = nothing
+
+        # Examine primary
+        if primary !== thin_primary
+            obj_p = object(primary)
+            if obj_p !== nothing
+                if dot(direction(ray), normal3d(primary)) > 0
+                    exiting_obj = obj_p
+                else
+                    entering_obj = obj_p
+                end
+            end
+        end
+
+        # Examine coin_1
+        if coin_1 !== thin_primary
+            obj_c1 = object(coin_1)
+            if obj_c1 !== nothing
+                if dot(direction(ray), normal3d(coin_1)) > 0
+                    exiting_obj = obj_c1
+                else
+                    entering_obj = obj_c1
+                end
+            end
+        end
+
+        # Examine coin_2
+        if coin_2 !== nothing && coin_2 !== thin_primary
+            obj_c2 = object(coin_2)
+            if obj_c2 !== nothing
+                if dot(direction(ray), normal3d(coin_2)) > 0
+                    exiting_obj = obj_c2
+                else
+                    entering_obj = obj_c2
+                end
+            end
+        end
+
+        thin_primary.coincident_object = exiting_obj
+        thin_primary.coincident_object_2 = entering_obj
+        return thin_primary
+    else
+        # Case 2: Touching refractive boundaries (doublet contact). Return the
+        # exiting shape as primary, and link the entering shape as coincident_object.
+        exiting_int = nothing
+        entering_int = nothing
+
+        # Examine primary
+        if dot(direction(ray), normal3d(primary)) > 0
+            exiting_int = primary
+        else
+            entering_int = primary
+        end
+
+        # Examine coin_1
+        if dot(direction(ray), normal3d(coin_1)) > 0
+            exiting_int = coin_1
+        else
+            entering_int = coin_1
+        end
+
+        # Examine coin_2
+        if coin_2 !== nothing
+            if dot(direction(ray), normal3d(coin_2)) > 0
+                exiting_int = coin_2
+            else
+                entering_int = coin_2
+            end
+        end
+
+        if exiting_int !== nothing && entering_int !== nothing
+            exiting_int.coincident_object = object(entering_int)
+            return exiting_int
+        elseif exiting_int !== nothing
+            return exiting_int
+        else
+            return primary
+        end
+    end
 end
 
 """
@@ -228,14 +469,9 @@ function retrace_system!(
         end
         # Recalculate current intersection
         if isnothing(_hint)
-            # Retrace intersection
-            intersection!(ray, intersect3d(object(_intersection), ray))
+            intersection!(ray, trace_all(system, ray))
         else
-            # Retrace hint
-            intersection!(ray, intersect3d(shape(_hint), ray))
-            if !isnothing(intersection(ray))
-                object!(intersection(ray), object(_hint))
-            end
+            intersection!(ray, trace_one(system, ray, _hint))
         end
         # Test if intersection is valid
         if isnothing(intersection(ray))
@@ -381,21 +617,17 @@ function retrace_system!(
             cutoff = i
             break
         end
-        # Recalculate current intersection (use shape of hint if available)
+        # Recalculate current intersection
         w_ray = rays(gauss.waist)[i]
         d_ray = rays(gauss.divergence)[i]
         if isnothing(_hint)
-            _object = object(_intersection)
-            _shape = shape(_intersection)
-            intersection!(c_ray, intersect3d(_object, c_ray))
-            intersection!(w_ray, intersect3d(_object, w_ray))
-            intersection!(d_ray, intersect3d(_object, d_ray))
+            intersection!(c_ray, trace_all(system, c_ray))
+            intersection!(w_ray, trace_all(system, w_ray))
+            intersection!(d_ray, trace_all(system, d_ray))
         else
-            _object = object(_hint)
-            _shape = BeamletOptics.shape(_hint)
-            intersection!(c_ray, intersect3d(_shape, c_ray))
-            intersection!(w_ray, intersect3d(_shape, w_ray))
-            intersection!(d_ray, intersect3d(_shape, d_ray))
+            intersection!(c_ray, trace_one(system, c_ray, _hint))
+            intersection!(w_ray, trace_one(system, w_ray, _hint))
+            intersection!(d_ray, trace_one(system, d_ray, _hint))
         end
         # Test if all beams still hit the same target
         if !_beams_hits_same_shape(gauss, i)
@@ -414,6 +646,7 @@ function retrace_system!(
             break
         end
         # Update object field
+        _object = object(intersection(c_ray))
         object!(intersection(c_ray), _object)
         object!(intersection(w_ray), _object)
         object!(intersection(d_ray), _object)
@@ -565,19 +798,16 @@ function retrace_system!(
             cutoff = i
             break
         end
-        # Recalculate current intersection (use shape of hint if available)
+        # Recalculate current intersection
         if isnothing(_hint)
-            _object = object(_intersection)
-            intersection!(c_ray, intersect3d(_object, c_ray))
+            intersection!(c_ray, trace_all(system, c_ray))
             for beam in aux
-                intersection!(rays(beam)[i], intersect3d(_object, rays(beam)[i]))
+                intersection!(rays(beam)[i], trace_all(system, rays(beam)[i]))
             end
         else
-            _object = object(_hint)
-            _shape = BeamletOptics.shape(_hint)
-            intersection!(c_ray, intersect3d(_shape, c_ray))
+            intersection!(c_ray, trace_one(system, c_ray, _hint))
             for beam in aux
-                intersection!(rays(beam)[i], intersect3d(_shape, rays(beam)[i]))
+                intersection!(rays(beam)[i], trace_one(system, rays(beam)[i], _hint))
             end
         end
         # Test if all beams still hit the same target
@@ -597,6 +827,7 @@ function retrace_system!(
             break
         end
         # Update object field
+        _object = object(intersection(c_ray))
         object!(intersection(c_ray), _object)
         for beam in aux
             r_int = intersection(rays(beam)[i])

--- a/src/System.jl
+++ b/src/System.jl
@@ -56,180 +56,8 @@ function retrace_system!(::AbstractSystem, beam::B) where {B <: AbstractBeam}
     return nothing
 end
 
-@inline function trace_all(system::AbstractSystem, ray::AbstractRay{R}) where {R}
-    tol = get_coincident_boundary_tolerance()
-    best_t = R(Inf)
-    best_int = nothing
-    coin_1 = nothing
-    coin_2 = nothing
-
-    # Find the closest intersection and collect any coincident ones at the same distance
-    for obj in objects(system)
-        temp = intersect3d(obj, ray)
-        if temp === nothing
-            continue
-        end
-        t = length(temp)
-
-        # Ignore self-intersection (t ≈ 0)
-        if t <= tol
-            continue
-        end
-
-        if t < best_t - tol
-            best_t = t
-            best_int = temp
-            coin_1 = nothing
-            coin_2 = nothing
-        elseif abs(t - best_t) <= tol
-            if coin_1 === nothing
-                coin_1 = temp
-            elseif coin_2 === nothing
-                coin_2 = temp
-            end
-        end
-    end
-
-    if best_int === nothing
-        return nothing
-    end
-
-    # Tie-break coincident boundaries
-    if coin_1 === nothing
-        return best_int
-    end
-
-    # Determine if any of the valid intersections is a thin interface
-    primary = nothing
-    if is_thin_interface(object(best_int))
-        primary = best_int
-    elseif is_thin_interface(object(coin_1))
-        primary = coin_1
-    elseif coin_2 !== nothing && is_thin_interface(object(coin_2))
-        primary = coin_2
-    end
-
-    if primary !== nothing
-        # Case 1: Thin interface (coating) between two media. Return the coating
-        # as primary, and link the exiting and entering objects to resolve indices.
-        exiting_obj = nothing
-        entering_obj = nothing
-
-        # Examine best_int
-        if best_int !== primary
-            obj_best = object(best_int)
-            if obj_best !== nothing
-                if dot(direction(ray), normal3d(best_int)) > 0
-                    exiting_obj = obj_best
-                else
-                    entering_obj = obj_best
-                end
-            end
-        end
-
-        # Examine coin_1
-        if coin_1 !== primary
-            obj_c1 = object(coin_1)
-            if obj_c1 !== nothing
-                if dot(direction(ray), normal3d(coin_1)) > 0
-                    exiting_obj = obj_c1
-                else
-                    entering_obj = obj_c1
-                end
-            end
-        end
-
-        # Examine coin_2
-        if coin_2 !== nothing && coin_2 !== primary
-            obj_c2 = object(coin_2)
-            if obj_c2 !== nothing
-                if dot(direction(ray), normal3d(coin_2)) > 0
-                    exiting_obj = obj_c2
-                else
-                    entering_obj = obj_c2
-                end
-            end
-        end
-
-        primary.coincident_object = exiting_obj
-        primary.coincident_object_2 = entering_obj
-        return primary
-    else
-        # Case 2: Touching refractive boundaries (doublet contact). Return the
-        # exiting shape as primary, and link the entering shape as coincident_object.
-        exiting_int = nothing
-        entering_int = nothing
-
-        # Examine best_int
-        if dot(direction(ray), normal3d(best_int)) > 0
-            exiting_int = best_int
-        else
-            entering_int = best_int
-        end
-
-        # Examine coin_1
-        if dot(direction(ray), normal3d(coin_1)) > 0
-            exiting_int = coin_1
-        else
-            entering_int = coin_1
-        end
-
-        # Examine coin_2
-        if coin_2 !== nothing
-            if dot(direction(ray), normal3d(coin_2)) > 0
-                exiting_int = coin_2
-            else
-                entering_int = coin_2
-            end
-        end
-
-        if exiting_int !== nothing && entering_int !== nothing
-            exiting_int.coincident_object = object(entering_int)
-            return exiting_int
-        elseif exiting_int !== nothing
-            return exiting_int
-        else
-            return best_int
-        end
-    end
-end
-
-@inline function trace_one(
-        system::AbstractSystem, ray::AbstractRay{R}, hint::Hint) where {R}
-    tol = get_coincident_boundary_tolerance()
-    # Trace against hinted shape of object first
-    primary::Nullable{Intersection{R}} = intersect3d(
-        shape(hint)::AbstractShape{R}, ray)
-    if primary === nothing
-        # If hinted object is not intersected, trace the entire system
-        return trace_all(system, ray)
-    end
-
-    object!(primary, object(hint))
-    t_best = length(primary)
-    if t_best <= tol
-        # Ignore self-intersection/coincident boundary re-entry
-        return trace_all(system, ray)
-    end
-
-    # Gather other intersections at the same distance to resolve cement/contact transitions
-    coin_1 = nothing
-    coin_2 = nothing
-    for obj in objects(system)
-        if obj === object(hint)
-            continue
-        end
-        temp = intersect3d(obj, ray)
-        if temp !== nothing && abs(length(temp) - t_best) <= tol
-            if coin_1 === nothing
-                coin_1 = temp
-            elseif coin_2 === nothing
-                coin_2 = temp
-            end
-        end
-    end
-
-    # If no coincident intersections, just return primary
+@inline function _tie_break_coincident(ray::AbstractRay, primary, coin_1, coin_2)
+    # Tie-break coincident boundaries without allocating array/tuples
     if coin_1 === nothing
         return primary
     end
@@ -327,6 +155,85 @@ end
             return primary
         end
     end
+end
+
+@inline function trace_all(system::AbstractSystem, ray::AbstractRay{R}) where {R}
+    tol = get_coincident_boundary_tolerance()
+    best_t = R(Inf)
+    best_int = nothing
+    coin_1 = nothing
+    coin_2 = nothing
+
+    # Find the closest intersection and collect any coincident ones at the same distance
+    for obj in objects(system)
+        temp = intersect3d(obj, ray)
+        if temp === nothing
+            continue
+        end
+        t = length(temp)
+
+        # Ignore self-intersection (t ≈ 0)
+        if t <= tol
+            continue
+        end
+
+        if t < best_t - tol
+            best_t = t
+            best_int = temp
+            coin_1 = nothing
+            coin_2 = nothing
+        elseif abs(t - best_t) <= tol
+            if coin_1 === nothing
+                coin_1 = temp
+            elseif coin_2 === nothing
+                coin_2 = temp
+            end
+        end
+    end
+
+    if best_int === nothing
+        return nothing
+    end
+
+    return _tie_break_coincident(ray, best_int, coin_1, coin_2)
+end
+
+@inline function trace_one(
+        system::AbstractSystem, ray::AbstractRay{R}, hint::Hint) where {R}
+    tol = get_coincident_boundary_tolerance()
+    # Trace against hinted shape of object first
+    primary::Nullable{Intersection{R}} = intersect3d(
+        shape(hint)::AbstractShape{R}, ray)
+    if primary === nothing
+        # If hinted object is not intersected, trace the entire system
+        return trace_all(system, ray)
+    end
+
+    object!(primary, object(hint))
+    t_best = length(primary)
+    if t_best <= tol
+        # Ignore self-intersection/coincident boundary re-entry
+        return trace_all(system, ray)
+    end
+
+    # Gather other intersections at the same distance to resolve cement/contact transitions
+    coin_1 = nothing
+    coin_2 = nothing
+    for obj in objects(system)
+        if obj === object(hint)
+            continue
+        end
+        temp = intersect3d(obj, ray)
+        if temp !== nothing && abs(length(temp) - t_best) <= tol
+            if coin_1 === nothing
+                coin_1 = temp
+            elseif coin_2 === nothing
+                coin_2 = temp
+            end
+        end
+    end
+
+    return _tie_break_coincident(ray, primary, coin_1, coin_2)
 end
 
 """


### PR DESCRIPTION
This pull request implements the coincident intersection resolution scheme we discussed, assuming up to three coincident objects can be returned by the trace functions within a distance threshold. In this "tie-breaker" logic, I handle sandwiched coatings (currently only the `ThinBeamsplitter`) and touching volumetric shapes (such as cemented doublet lenses). These coincident elements are then stored directly in the `Intersection` object context. This allows specialized `interact3d` methods to query adjacent exiting/entering components and tailor custom refraction or reflection behavior without needing global lookups.

At least as of now, this merge request actually almost removes more code than it adds to BMO as we can now get rid of some "stupid" methods. The number of lines is just more at the moment, because my VSCode auto-reformatted some code.